### PR TITLE
add support version of exif to properly read rotation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.github.dotloop:aosp-exif:be25ae51ec'
+    compile 'com.android.support:exifinterface:25.3.1'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 25
         versionCode 14
         versionName "0.0.14"
     }
@@ -22,8 +22,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
+    compile 'com.android.support:exifinterface:25.3.1'
+    compile 'com.android.support:design:25.3.1'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.github.dotloop:aosp-exif:be25ae51ec'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 14
         versionName "0.0.14"
     }
@@ -22,10 +22,9 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:exifinterface:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:exifinterface:26.1.0'
+    compile 'com.android.support:design:26.1.0'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.github.dotloop:aosp-exif:be25ae51ec'
-    compile 'com.android.support:exifinterface:25.3.1'
 }

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -204,8 +204,6 @@ public class ImageResizer {
         //rotate original image because camera takes them side ways
         Matrix matrix = new Matrix();
         matrix.postRotate(rotationInDegrees);
-        exif.setAttribute(android.support.media.ExifInterface.TAG_ORIENTATION,
-                          String.valueOf(android.support.media.ExifInterface.ORIENTATION_NORMAL));
         return Bitmap.createBitmap(bitmap , 0, 0, bitmap.getWidth(),
             bitmap.getHeight(), matrix, true);
     }
@@ -249,7 +247,7 @@ public class ImageResizer {
                 String fileName = String.format(Locale.US, FILE_NAME_FORMAT, savedFiles++);
                 os = context.openFileOutput(fileName, Context.MODE_PRIVATE);
 
-                ExifInterface exif = new ExifInterface();
+                //ExifInterface exif = new ExifInterface();
 
                 boolean isJpeg = false;
                 try {
@@ -259,18 +257,29 @@ public class ImageResizer {
                 }
 
                 if (isJpeg) {
-                    exif.readExif(context.getContentResolver().openInputStream(sourceUri));
                     out = rotateImage( sourceUri, out);
                 }
-                if (exif.getAllTags() != null) {
-                    exif.writeExif(out, os);
-                } else {
-                    ExifInterface exif2 = new ExifInterface();
-                    exif2.addDateTimeStampTag(ExifInterface.TAG_DATE_TIME_ORIGINAL, Calendar.getInstance().getTime().getTime(), TimeZone.getDefault());
-                    exif2.writeExif(out, os);
-                }
+                out.compress(Bitmap.CompressFormat.JPEG, 100, os);
+//                 if (exif.getAllTags() != null) {
+//                     out.compress(Bitmap.CompressFormat.JPEG, 100, os);
+//                     //exif.writeExif(out, os);
+                    
+//                 } else {
+//                     out.compress(Bitmap.CompressFormat.JPEG, 100, os);
+//                     //ExifInterface exif2 = new ExifInterface();
+//                     //exif2.addDateTimeStampTag(ExifInterface.TAG_DATE_TIME_ORIGINAL, Calendar.getInstance().getTime().getTime(), TimeZone.getDefault());
+//                     //exif2.writeExif(out, os);
+//                 }
 
                 dstUri = Uri.fromFile(context.getFileStreamPath(fileName));
+                android.support.media.ExifInterface exif = 
+                    new android.support.media.ExifInterface(context.getContentResolver().openInputStream(dstUri));
+                 exif.setAttribute(android.support.media.ExifInterface.TAG_ORIENTATION,
+                          String.valueOf(android.support.media.ExifInterface.ORIENTATION_NORMAL));
+                exif.setAttribute(android.support.media.ExifInterface.TAG_DATETIME_ORIGINAL,
+                                  String.valueOf(Calendar.getInstance().getTime().getTime()));
+                exif.saveAttributes();
+                
             } catch (IOException e) {
                 e.printStackTrace();
             } finally {

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -10,7 +10,6 @@ import android.util.Log;
 import com.android.mms.exif.ExifInterface;
 import com.isbx.androidtools.utils.ExifInterfaceAndroid;
 
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -6,9 +6,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.Uri;
 import android.util.Log;
-
-import com.android.mms.exif.ExifInterface;
-
+import android.support.media.ExifInterface;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -195,9 +193,9 @@ public class ImageResizer {
 
     public Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
         Bitmap bitmap = sourceImage;
-        android.support.media.ExifInterface exif = new android.support.media.ExifInterface(context.getContentResolver().openInputStream(imageUri));
-        int rotation = exif.getAttributeInt(android.support.media.ExifInterface.TAG_ORIENTATION, 
-                                            android.support.media.ExifInterface.ORIENTATION_NORMAL);
+        ExifInterface exif = new ExifInterface(context.getContentResolver().openInputStream(imageUri));
+        int rotation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 
+                                            ExifInterface.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
         Log.i("DEV", String.valueOf(rotationInDegrees) + " degrees rotated");
 
@@ -209,9 +207,9 @@ public class ImageResizer {
     }
 
     private int exifToDegrees(int exifOrientation) {
-        if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_90) { return 90; }
-        else if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_180) {  return 180; }
-        else if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_270) {  return 270; }
+        if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90) { return 90; }
+        else if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_180) {  return 180; }
+        else if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_270) {  return 270; }
         return 0;
     }
 
@@ -246,9 +244,6 @@ public class ImageResizer {
                 }
                 String fileName = String.format(Locale.US, FILE_NAME_FORMAT, savedFiles++);
                 os = context.openFileOutput(fileName, Context.MODE_PRIVATE);
-
-                //ExifInterface exif = new ExifInterface();
-
                 boolean isJpeg = false;
                 try {
                     isJpeg = imageIsJPEG(sourceUri);
@@ -260,23 +255,12 @@ public class ImageResizer {
                     out = rotateImage( sourceUri, out);
                 }
                 out.compress(Bitmap.CompressFormat.JPEG, 100, os);
-//                 if (exif.getAllTags() != null) {
-//                     out.compress(Bitmap.CompressFormat.JPEG, 100, os);
-//                     //exif.writeExif(out, os);
-                    
-//                 } else {
-//                     out.compress(Bitmap.CompressFormat.JPEG, 100, os);
-//                     //ExifInterface exif2 = new ExifInterface();
-//                     //exif2.addDateTimeStampTag(ExifInterface.TAG_DATE_TIME_ORIGINAL, Calendar.getInstance().getTime().getTime(), TimeZone.getDefault());
-//                     //exif2.writeExif(out, os);
-//                 }
-
                 dstUri = Uri.fromFile(context.getFileStreamPath(fileName));
-                android.support.media.ExifInterface exif = 
-                    new android.support.media.ExifInterface(context.getContentResolver().openInputStream(dstUri));
-                 exif.setAttribute(android.support.media.ExifInterface.TAG_ORIENTATION,
-                          String.valueOf(android.support.media.ExifInterface.ORIENTATION_NORMAL));
-                exif.setAttribute(android.support.media.ExifInterface.TAG_DATETIME_ORIGINAL,
+                ExifInterface exif = 
+                    new ExifInterface(context.getContentResolver().openInputStream(dstUri));
+                 exif.setAttribute(ExifInterface.TAG_ORIENTATION,
+                          String.valueOf(ExifInterface.ORIENTATION_NORMAL));
+                exif.setAttribute(ExifInterface.TAG_DATETIME_ORIGINAL,
                                   String.valueOf(Calendar.getInstance().getTime().getTime()));
                 exif.saveAttributes();
                 

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -196,22 +196,24 @@ public class ImageResizer {
     public Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
         Bitmap bitmap = sourceImage;
         android.support.media.ExifInterface exif = new android.support.media.ExifInterface(context.getContentResolver().openInputStream(imageUri));
-        int rotation = exif.getAttributeInt(ExifInterfaceAndroid.TAG_ORIENTATION, ExifInterfaceAndroid.ORIENTATION_NORMAL);
+        int rotation = exif.getAttributeInt(android.support.media.ExifInterface.TAG_ORIENTATION, 
+                                            android.support.media.ExifInterface.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
         Log.i("DEV", String.valueOf(rotationInDegrees) + " degrees rotated");
 
         //rotate original image because camera takes them side ways
         Matrix matrix = new Matrix();
         matrix.postRotate(rotationInDegrees);
-        exif.setAttribute(ExifInterfaceAndroid.TAG_ORIENTATION, String.valueOf(ExifInterfaceAndroid.ORIENTATION_NORMAL));
+        exif.setAttribute(android.support.media.ExifInterface.TAG_ORIENTATION,
+                          String.valueOf(android.support.media.ExifInterface.ORIENTATION_NORMAL));
         return Bitmap.createBitmap(bitmap , 0, 0, bitmap.getWidth(),
             bitmap.getHeight(), matrix, true);
     }
 
     private int exifToDegrees(int exifOrientation) {
-        if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_90) { return 90; }
-        else if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_180) {  return 180; }
-        else if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_270) {  return 270; }
+        if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_90) { return 90; }
+        else if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_180) {  return 180; }
+        else if (exifOrientation == android.support.media.ExifInterface.ORIENTATION_ROTATE_270) {  return 270; }
         return 0;
     }
 

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -194,7 +194,7 @@ public class ImageResizer {
         }
     };
 
-    public static Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
+    public Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
         Bitmap bitmap = sourceImage;
         ExifInterfaceAndroid exif = new ExifInterfaceAndroid(context.getContentResolver().openInputStream(imageUri));
         int rotation = exif.getAttributeInt(ExifInterfaceAndroid.TAG_ORIENTATION, ExifInterfaceAndroid.ORIENTATION_NORMAL);
@@ -209,7 +209,7 @@ public class ImageResizer {
             bitmap.getHeight(), matrix, true);
     }
 
-    private static int exifToDegrees(int exifOrientation) {
+    private int exifToDegrees(int exifOrientation) {
         if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_90) { return 90; }
         else if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_180) {  return 180; }
         else if (exifOrientation == ExifInterfaceAndroid.ORIENTATION_ROTATE_270) {  return 270; }

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.android.mms.exif.ExifInterface;
-import com.isbx.androidtools.utils.ExifInterfaceAndroid;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
@@ -196,7 +195,7 @@ public class ImageResizer {
 
     public Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
         Bitmap bitmap = sourceImage;
-        ExifInterfaceAndroid exif = new ExifInterfaceAndroid(context.getContentResolver().openInputStream(imageUri));
+        android.support.media.ExifInterface exif = new android.support.media.ExifInterface(context.getContentResolver().openInputStream(imageUri));
         int rotation = exif.getAttributeInt(ExifInterfaceAndroid.TAG_ORIENTATION, ExifInterfaceAndroid.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
         Log.i("DEV", String.valueOf(rotationInDegrees) + " degrees rotated");

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -200,7 +200,8 @@ public class ImageResizer {
         ExifInterfaceAndroid exif = new ExifInterfaceAndroid(imageUri.getPath());
         int rotation = exif.getAttributeInt(ExifInterfaceAndroid.TAG_ORIENTATION, ExifInterfaceAndroid.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
-        Log.d("HELLO", String.valueOf(rotationInDegrees));
+        Log.i("HELLO", String.valueOf(rotationInDegrees));
+        Log.i("HELLO", "degrees rotated");
 
         //rotate original image because camera takes them side ways
         Matrix matrix = new Matrix();
@@ -219,6 +220,7 @@ public class ImageResizer {
 
     public Uri scaleImage(Uri sourceUri, ImageResizeConfig.Dimension targetDimension) {
         Uri dstUri = null;
+        Log.i("HELLO", "calling scaleImage");
 
         Bitmap bm = null;
         try {
@@ -257,10 +259,11 @@ public class ImageResizer {
                 } catch(Exception e) {
                     e.printStackTrace();
                 }
-                Log.d("HELLO", "WE IN THE MUFUGGA");
+
                 if (isJpeg) {
 
                     exif.readExif(context.getContentResolver().openInputStream(sourceUri));
+                    Log.i("HELLO", "about to call rotateImage");
                     out = rotateImage( sourceUri, out);
                 }
                 if (exif.getAllTags() != null) {

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -207,8 +207,8 @@ public class ImageResizer {
         Matrix matrix = new Matrix();
         matrix.postRotate(rotationInDegrees);
         exif.setAttribute(ExifInterfaceAndroid.TAG_ORIENTATION, String.valueOf(ExifInterfaceAndroid.ORIENTATION_NORMAL));
-        return Bitmap.createBitmap(bitmap , 0, 0, rotationInDegrees % 180 == 0 ? bitmap.getWidth() : bitmap.getHeight(),
-                rotationInDegrees % 180 == 0 ? bitmap.getHeight() : bitmap.getWidth(), matrix, true);
+        return Bitmap.createBitmap(bitmap , 0, 0, bitmap.getWidth(),
+            bitmap.getWidth(), matrix, true);
     }
 
     private static int exifToDegrees(int exifOrientation) {

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -197,11 +197,10 @@ public class ImageResizer {
 
     public static Bitmap rotateImage(Uri imageUri, Bitmap sourceImage) throws IOException {
         Bitmap bitmap = sourceImage;
-        ExifInterfaceAndroid exif = new ExifInterfaceAndroid(imageUri.getPath());
+        ExifInterfaceAndroid exif = new ExifInterfaceAndroid(context.getContentResolver().openInputStream(imageUri));
         int rotation = exif.getAttributeInt(ExifInterfaceAndroid.TAG_ORIENTATION, ExifInterfaceAndroid.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
-        Log.i("HELLO", String.valueOf(rotationInDegrees));
-        Log.i("HELLO", "degrees rotated");
+        Log.i("DEV", String.valueOf(rotationInDegrees) + " degrees rotated");
 
         //rotate original image because camera takes them side ways
         Matrix matrix = new Matrix();
@@ -220,7 +219,6 @@ public class ImageResizer {
 
     public Uri scaleImage(Uri sourceUri, ImageResizeConfig.Dimension targetDimension) {
         Uri dstUri = null;
-        Log.i("HELLO", "calling scaleImage");
 
         Bitmap bm = null;
         try {
@@ -261,9 +259,7 @@ public class ImageResizer {
                 }
 
                 if (isJpeg) {
-
                     exif.readExif(context.getContentResolver().openInputStream(sourceUri));
-                    Log.i("HELLO", "about to call rotateImage");
                     out = rotateImage( sourceUri, out);
                 }
                 if (exif.getAllTags() != null) {

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -197,7 +197,6 @@ public class ImageResizer {
         int rotation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 
                                             ExifInterface.ORIENTATION_NORMAL);
         int rotationInDegrees = exifToDegrees(rotation);
-        Log.i("DEV", String.valueOf(rotationInDegrees) + " degrees rotated");
 
         //rotate original image because camera takes them side ways
         Matrix matrix = new Matrix();

--- a/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
+++ b/core/src/main/java/com/isbx/androidtools/media/ImageResizer.java
@@ -206,7 +206,7 @@ public class ImageResizer {
         matrix.postRotate(rotationInDegrees);
         exif.setAttribute(ExifInterfaceAndroid.TAG_ORIENTATION, String.valueOf(ExifInterfaceAndroid.ORIENTATION_NORMAL));
         return Bitmap.createBitmap(bitmap , 0, 0, bitmap.getWidth(),
-            bitmap.getWidth(), matrix, true);
+            bitmap.getHeight(), matrix, true);
     }
 
     private static int exifToDegrees(int exifOrientation) {

--- a/core/src/main/java/com/isbx/androidtools/utils/ExifInterfaceAndroid.java
+++ b/core/src/main/java/com/isbx/androidtools/utils/ExifInterfaceAndroid.java
@@ -1,0 +1,17 @@
+package com.isbx.androidtools.utils;
+
+import android.media.ExifInterface;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Created by rwieghard on 1/29/18.
+ */
+
+public class ExifInterfaceAndroid extends ExifInterface {
+    public ExifInterfaceAndroid(String filename) throws IOException {
+        super(filename);
+    }
+}

--- a/core/src/main/java/com/isbx/androidtools/utils/ExifInterfaceAndroid.java
+++ b/core/src/main/java/com/isbx/androidtools/utils/ExifInterfaceAndroid.java
@@ -1,6 +1,6 @@
 package com.isbx.androidtools.utils;
 
-import android.media.ExifInterface;
+import android.support.media.ExifInterface;
 
 import java.io.FileDescriptor;
 import java.io.IOException;

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.25'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.26'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.16'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.23'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.24'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
+    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.23'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.26'
+    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.16'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:master-SNAPSHOT'
+    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.24'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.25'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:master-SNAPSHOT'
+    compile 'com.github.acrimi.AndroidUtils:core:master-SNAPSHOT'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.23'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.23'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.18'
 }

--- a/databinding/build.gradle
+++ b/databinding/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.18'
+    compile 'com.github.ebbnormal.AndroidUtils:core:master-SNAPSHOT'
 }

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.16'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.23'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.26'
+    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.acrimi.AndroidUtils:core:master-SNAPSHOT'
+    compile 'com.github.acrimi.AndroidUtils:core:core_0.0.14'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.25'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.26'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.18'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.23'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.24'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.15'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.16'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.18'
+    compile 'com.github.ebbnormal.AndroidUtils:core:master-SNAPSHOT'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.24'
+    compile 'com.github.ebbnormal.AndroidUtils:core:core_0.0.25'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.ebbnormal.AndroidUtils:core:master-SNAPSHOT'
+    compile 'com.github.acrimi.AndroidUtils:core:master-SNAPSHOT'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-places:11.4.2'


### PR DESCRIPTION
this change uses the support version of the [exifinterface](https://android-developers.googleblog.com/2016/12/introducing-the-exifinterface-support-library.html) library and uses it to properly read the rotation tags on JPEG and finally rotates the image if necessary before writing to the output stream. @acrimi if this could be expedited for the purposes of it being for the sake of the _Krankenschwestere_ of the _Vereinigtestaaten._ 